### PR TITLE
Adds new role for Nginx

### DIFF
--- a/provision_profiles/nginx.yml
+++ b/provision_profiles/nginx.yml
@@ -1,0 +1,8 @@
+- name: Provisions Nginx (running inside Docker)
+  hosts: all
+  sudo: yes
+
+  roles:
+    - unattended-upgrades
+    - docker.ubuntu
+    - nginx

--- a/provision_profiles/roles/nginx/files/index.html
+++ b/provision_profiles/roles/nginx/files/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+
+    <!-- Optional theme -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css" integrity="sha384-fLW2N01lMqjakBkx3l/M9EahuwpSfeNvV63J5ezn3uZzapT0u7EYsXMjQV+0En5r" crossorigin="anonymous">
+
+    <!-- Latest compiled and minified JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+
+    <!-- Custom styles for this template -->
+    <link href="https://getbootstrap.com/examples/sticky-footer/sticky-footer.css" rel="stylesheet">
+
+    <title>Web application placeholder.</title>
+  </head>
+  <body>
+    <div class="container">
+      <div class="page-header">
+        <h1>Web application placeholder</h1>
+      </div>
+      <p class="lead">This is a web page placeholder. This will show up if no application is installed or configured.</p>
+      <p>Please see the post installation notes for how to configure the server.</p>
+    </div>
+
+    <footer class="footer">
+      <div class="container">
+        <p class="text-muted">This server was configured using <a href="https://github.com/OnApp/provisioner">Provisioner</a>.</p>
+      </div>
+    </footer>
+
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+  </body>
+</html>

--- a/provision_profiles/roles/nginx/tasks/main.yml
+++ b/provision_profiles/roles/nginx/tasks/main.yml
@@ -6,7 +6,8 @@
   with_items:
   - /etc/nginx/conf.d
   - /var/www
-  - /etc/ssl/certs
+  - /etc/ssl/private
+  - /etc/letsencrypt
 
 - name: Create config files
   template:
@@ -22,10 +23,19 @@
     force: no
 
 - name: Generate DH file
-  command: openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048 creates=/etc/ssl/certs/dhparam.pem
+  command: openssl dhparam -out /etc/ssl/private/dhparam.pem 2048 creates=/etc/ssl/private/dhparam.pem
 
 - name: Generate self-signed certificate as a placeholder
-  command: openssl req -new -nodes -x509 -subj "/C=US/ST=London/L=London/O=IT/CN=${ansible_fqdn}" -days 3650 -keyout "/etc/ssl/certs/{{ ansible_fqdn }}.key" -out "/etc/ssl/certs/{{ ansible_fqdn }}.crt" -extensions v3_ca creates="/etc/ssl/certs/{{ ansible_fqdn }}.crt"
+  command: openssl req -new -nodes -x509 -subj "/C=GB/ST=London/L=London/O=IT/CN={{ ansible_fqdn }}" -days 3650 -keyout "/etc/ssl/private/{{ ansible_fqdn }}-snakeoil.key" -out "/etc/ssl/private/{{ ansible_fqdn }}-snakeoil.crt" -extensions v3_ca creates="/etc/ssl/private/{{ ansible_fqdn }}-snakeoil.crt"
+
+- name: Creates symlinks to certificates
+  file:
+    src: "/etc/ssl/private/{{ ansible_fqdn }}-snakeoil.{{ item }}"
+    dest: "/etc/ssl/private/{{ ansible_fqdn }}.{{ item }}"
+    state: link
+  with_items:
+  - crt
+  - key
 
 - name: Nginx
   docker:
@@ -39,5 +49,6 @@
     - "443:443"
     volumes:
     - "/etc/nginx/conf.d:/etc/nginx/conf.d:ro"
-    - "/etc/ssl/certs:/etc/ssl/certs:ro"
+    - "/etc/ssl/private:/etc/ssl/private:ro"
     - "/var/www:/var/www:ro"
+    - "/etc/letsencrypt:/etc/letsencrypt:ro"

--- a/provision_profiles/roles/nginx/tasks/main.yml
+++ b/provision_profiles/roles/nginx/tasks/main.yml
@@ -6,7 +6,7 @@
   with_items:
   - /etc/nginx/conf.d
   - /var/www
-  - "/etc/letsencrypt/live/{{ ansible_fqdn }}"
+  - /etc/ssl/certs
 
 - name: Create config files
   template:
@@ -25,7 +25,7 @@
   command: openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048 creates=/etc/ssl/certs/dhparam.pem
 
 - name: Generate self-signed certificate as a placeholder
-  command: openssl req -new -nodes -x509 -subj "/C=US/ST=London/L=London/O=IT/CN=${ansible_fqdn}" -days 3650 -keyout "/etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem" -out "/etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem" -extensions v3_ca creates="/etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem"
+  command: openssl req -new -nodes -x509 -subj "/C=US/ST=London/L=London/O=IT/CN=${ansible_fqdn}" -days 3650 -keyout "/etc/ssl/certs/{{ ansible_fqdn }}.key" -out "/etc/ssl/certs/{{ ansible_fqdn }}.crt" -extensions v3_ca creates="/etc/ssl/certs/{{ ansible_fqdn }}.crt"
 
 - name: Nginx
   docker:
@@ -39,6 +39,5 @@
     - "443:443"
     volumes:
     - "/etc/nginx/conf.d:/etc/nginx/conf.d:ro"
-    - "/etc/letsencrypt/live/{{ ansible_fqdn }}:/etc/letsencrypt/live/{{ ansible_fqdn }}:ro"
-    - "/etc/ssl/certs/dhparam.pem:/etc/ssl/certs/dhparam.pem:ro"
+    - "/etc/ssl/certs:/etc/ssl/certs:ro"
     - "/var/www:/var/www:ro"

--- a/provision_profiles/roles/nginx/tasks/main.yml
+++ b/provision_profiles/roles/nginx/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+- name: Create required folders
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+  - /etc/nginx/conf.d
+  - /var/www
+  - "/etc/letsencrypt/live/{{ ansible_fqdn }}"
+
+- name: Create config files
+  template:
+    src: "{{ item }}.j2"
+    dest: "/etc/nginx/conf.d/{{ item }}"
+  with_items:
+  - default.conf
+
+- name: Copies in sample index.html
+  copy:
+    src: index.html
+    dest: /var/www/index.html
+    force: no
+
+- name: Generate DH file
+  command: openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048 creates=/etc/ssl/certs/dhparam.pem
+
+- name: Generate self-signed certificate as a placeholder
+  command: openssl req -new -nodes -x509 -subj "/C=US/ST=London/L=London/O=IT/CN=${ansible_fqdn}" -days 3650 -keyout "/etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem" -out "/etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem" -extensions v3_ca creates="/etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem"
+
+- name: Nginx
+  docker:
+    name: nginx
+    image: nginx
+    state: started
+    restart_policy: on-failure
+    restart_policy_retry: 10
+    ports:
+    - "80:80"
+    - "443:443"
+    volumes:
+    - "/etc/nginx/conf.d:/etc/nginx/conf.d:ro"
+    - "/etc/letsencrypt/live/{{ ansible_fqdn }}:/etc/letsencrypt/live/{{ ansible_fqdn }}:ro"
+    - "/etc/ssl/certs/dhparam.pem:/etc/ssl/certs/dhparam.pem:ro"
+    - "/var/www:/var/www:ro"

--- a/provision_profiles/roles/nginx/templates/default.conf.j2
+++ b/provision_profiles/roles/nginx/templates/default.conf.j2
@@ -10,6 +10,8 @@ server {
   }
 
   location ~ /.well-known {
+    root /var/www;
+    try_files $uri $uri/ =404;
     allow all;
   }
 }
@@ -46,6 +48,8 @@ server {
   }
 
   location ~ /.well-known {
+    root /var/www;
+    try_files $uri $uri/ =404;
     allow all;
   }
 }

--- a/provision_profiles/roles/nginx/templates/default.conf.j2
+++ b/provision_profiles/roles/nginx/templates/default.conf.j2
@@ -20,8 +20,8 @@ server {
   listen 443 ssl;
   server_name {{ ansible_fqdn }};
 
-  ssl_certificate /etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem;
+  ssl_certificate /etc/ssl/certs/{{ ansible_fqdn }}.crt;
+  ssl_certificate_key /etc/ssl/certs/{{ ansible_fqdn }}.key;
 
   # from https://cipherli.st/
   # and https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html

--- a/provision_profiles/roles/nginx/templates/default.conf.j2
+++ b/provision_profiles/roles/nginx/templates/default.conf.j2
@@ -20,8 +20,8 @@ server {
   listen 443 ssl;
   server_name {{ ansible_fqdn }};
 
-  ssl_certificate /etc/ssl/certs/{{ ansible_fqdn }}.crt;
-  ssl_certificate_key /etc/ssl/certs/{{ ansible_fqdn }}.key;
+  ssl_certificate /etc/ssl/private/{{ ansible_fqdn }}.crt;
+  ssl_certificate_key /etc/ssl/private/{{ ansible_fqdn }}.key;
 
   # from https://cipherli.st/
   # and https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
@@ -40,7 +40,7 @@ server {
   add_header X-Frame-Options DENY;
   add_header X-Content-Type-Options nosniff;
 
-  ssl_dhparam /etc/ssl/certs/dhparam.pem;
+  ssl_dhparam /etc/ssl/private/dhparam.pem;
 
   location / {
     root   /var/www;

--- a/provision_profiles/roles/nginx/templates/default.conf.j2
+++ b/provision_profiles/roles/nginx/templates/default.conf.j2
@@ -1,0 +1,51 @@
+# vim: tabstop=2 shiftwidth=2 softtabstop=2
+
+server {
+  listen 80;
+  server_name {{ ansible_fqdn }};
+
+  location / {
+    root   /var/www;
+    index  index.html index.htm;
+  }
+
+  location ~ /.well-known {
+    allow all;
+  }
+}
+
+server {
+  listen 443 ssl;
+  server_name {{ ansible_fqdn }};
+
+  ssl_certificate /etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem;
+
+  # from https://cipherli.st/
+  # and https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+  ssl_ecdh_curve secp384r1;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_tickets off;
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  resolver 8.8.8.8 8.8.4.4 valid=300s;
+  resolver_timeout 5s;
+  add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+  add_header X-Frame-Options DENY;
+  add_header X-Content-Type-Options nosniff;
+
+  ssl_dhparam /etc/ssl/certs/dhparam.pem;
+
+  location / {
+    root   /var/www;
+    index  index.html index.htm;
+  }
+
+  location ~ /.well-known {
+    allow all;
+  }
+}

--- a/settings.py
+++ b/settings.py
@@ -32,6 +32,8 @@ PLAYBOOKS = SINGLE_HOST_PLAYBOOKS + CLUSTER_PLAYBOOKS
 
 HIDDEN_PLAYBOOKS = [
     'dns',
+    'letsencrypt,'
+    'nginx',
 ]
 
 MODULES = [

--- a/settings.py
+++ b/settings.py
@@ -14,6 +14,7 @@ SINGLE_HOST_PLAYBOOKS = [
     'joomla',
     'mongodb',
     'mysql',
+    'nginx',
     'owncloud',
     'postgres',
     'redis',


### PR DESCRIPTION
In order to deploy multiple roles on the same server, we need to take steps towards preventing port collisions etc. By placing a load balancer in front of the applications, we are able to dynamically route traffic accordingly. 

The design philosophy is as follows:

* Nginx listens on http://0.0.0.0 and  https://0.0.0.0. This is the 'default'  application
* Each app registers a new upstream port on 127.0.0.1:N, where N is a unique port by placing an new file in `/etc/nginx/conf.d`. 
* In addition to registering itself as an upstream, we will also introduce a new route `/app-name` as well as a variable in the config file to route to a 'default' app.