### PR TITLE
Migrates to shared MySQL

### DIFF
--- a/lib/ansible_helper.py
+++ b/lib/ansible_helper.py
@@ -103,6 +103,7 @@ def provision(
         extra_vars['mysql_root_password'] = generate_password()
 
         if not role == 'mysql':
+            extra_vars['mysql_{}_user'.format(role)] = role
             extra_vars['mysql_{}_password'.format(role)] = generate_password()
 
     if role in [
@@ -112,6 +113,7 @@ def provision(
         extra_vars['postgres_postgres_password'] = generate_password()
 
         if not role == 'postgres':
+            extra_vars['postgres_{}_user'.format(role)] = role
             extra_vars['postgres_{}_password'.format(role)] = generate_password()
 
     if remote_user and remote_pass and inventory:

--- a/lib/ansible_helper.py
+++ b/lib/ansible_helper.py
@@ -102,20 +102,17 @@ def provision(
     ]:
         extra_vars['mysql_root_password'] = generate_password()
 
-        if role == 'owncloud':
-            extra_vars['mysql_owncloud_password'] = generate_password()
-        if role == 'redmine':
-            extra_vars['mysql_redmine_password'] = generate_password()
-        if role == 'joomla':
-            extra_vars['mysql_joomla_password'] = generate_password()
+        if not role == 'mysql':
+            extra_vars['mysql_{}_password'.format(role)] = generate_password()
 
     if role in [
         'postgres',
         'drupal',
     ]:
         extra_vars['postgres_postgres_password'] = generate_password()
-        if role == 'drupal':
-            extra_vars['postgres_drupal_password'] = generate_password()
+
+        if not role == 'postgres':
+            extra_vars['postgres_{}_password'.format(role)] = generate_password()
 
     if remote_user and remote_pass and inventory:
         return run_playbook(

--- a/lib/doc_parser.py
+++ b/lib/doc_parser.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from bottle import template
 
@@ -17,5 +18,6 @@ def get_docs(role=None, extra_vars=None):
     try:
         install_notes = template(docs_uri, **extra_vars)
         return install_notes
-    except:
+    except Exception as e:
+        logging.exception("Failed to process install notes")
         return 'Failed to process installation notes.'

--- a/provision_profiles/joomla.yml
+++ b/provision_profiles/joomla.yml
@@ -4,9 +4,10 @@
 
   vars:
     - mysql_joomla_password:
+    - mysql_joomla_user:
     - mysql_root_password:
-
   roles:
     - unattended-upgrades
     - docker.ubuntu
+    - mysql
     - joomla

--- a/provision_profiles/joomla_install_notes.tpl
+++ b/provision_profiles/joomla_install_notes.tpl
@@ -8,9 +8,9 @@ Congratulations! You've just installed a Joomla! server.
  * Fill out the required information to create your administrator account
  * Use the following information in the next step to configure the database:
   * Host Name: `mysql`
-  * Username: `joomla`
+  * Username: `{{ mysql_joomla_user }}`
   * Password: `{{ mysql_joomla_password }}`
-  * Database Name: `joomla`
+  * Database Name: `{{ mysql_joomla_user }}`
  * Follow the installation wizard
  * Make sure you click 'Remove Installation Folder' in the last step
 
@@ -34,9 +34,6 @@ $ docker run -it --link mysql:mysql --rm mariadb sh -c 'exec mysql -hmysql -uroo
 
 ## MySQL
 
-User: root
-Password: `{{ mysql_root_password }}`
-
-User: joomla
+User: {{ mysql_joomla_user }}
 Password: `{{ mysql_joomla_password }}`
-Database: joomla
+Database: {{ mysql_joomla_user }}

--- a/provision_profiles/owncloud.yml
+++ b/provision_profiles/owncloud.yml
@@ -5,8 +5,9 @@
   vars:
     - mysql_root_password:
     - mysql_owncloud_password:
-
+    - mysql_owncloud_user:
   roles:
     - unattended-upgrades
     - docker.ubuntu
+    - mysql
     - owncloud

--- a/provision_profiles/owncloud_install_notes.tpl
+++ b/provision_profiles/owncloud_install_notes.tpl
@@ -4,13 +4,13 @@ Congratulations! You've just installed an Owncloud server.
 
 # Owncloud Installation Notes
 
- * Point your browser to http://{{ public_ip }}
+ * Point your browser to [http://{{ public_ip  }}](http://{{ public_ip }})
  * Enter a username and password to create your administrator account
  * Click 'Storage & Database'
   * Select 'MySQL/MariaDB'
-  * Enter 'owncloud' as Database user
+  * Enter '{{ mysql_owncloud_user }}' as Database user
   * Enter '{{ mysql_owncloud_password  }}' as the password
-  * Enter 'owncloud' as the Database name
+  * Enter '{{ mysql_owncloud_user }}' as the Database name
   * Enter 'mysql' as the Database host
  * Click  Finish Setup
 
@@ -31,8 +31,6 @@ $ docker run -it --link mysql:mysql --rm mariadb sh -c 'exec mysql -hmysql -uroo
 
 ## MySQL
 
-User: root
-Password: {{ mysql_root_password  }}
-
-User: owncloud
+Database: {{ mysql_owncloud_user }}
+User: {{ mysql_owncloud_user }}
 Password: {{ mysql_owncloud_password }}

--- a/provision_profiles/redmine_install_notes.tpl
+++ b/provision_profiles/redmine_install_notes.tpl
@@ -4,11 +4,10 @@ Congratulations! You've just installed a Redmine server.
 
 # Redmine Installation Notes
 
- * Point your browser to http://{{ public_ip }
+* Point your browser to [http://{{ public_ip  }}](http://{{ public_ip })
  * Press the 'login' link in the upper right-hand corner and login with the credentials 'admin'/'admin'
  * Click 'My Account' in the upper right-hand corner and select 'Change password'
  * Assign a new password to the administrator account
-
 
 # Technical Details
 
@@ -28,9 +27,6 @@ $ docker run -it --link mysql:mysql --rm mariadb sh -c 'exec mysql -hmysql -uroo
 
 ## MySQL
 
-User: root
-Password: `{{ mysql_root_password  }}`
-
-User: redmine
-Database: redmine
+User: {{ mysql_redmine_user }}
+Database: {{ mysql_redmine_user }}
 Password: `{{ mysql_redmine_password }}`

--- a/provision_profiles/roles/joomla/tasks/main.yml
+++ b/provision_profiles/roles/joomla/tasks/main.yml
@@ -1,17 +1,6 @@
 ---
-- name: MySQL
-  docker:
-    name: mysql
-    image: mariadb
-    state: started
-    restart_policy: always
-    env:
-      MYSQL_ROOT_PASSWORD: "{{ mysql_root_password }}"
-      MYSQL_USER: joomla
-      MYSQL_PASSWORD: "{{ mysql_joomla_password }}"
-      MYSQL_DATABASE: joomla
-    volumes:
-    - "/var/lib/mysql:/var/lib/mysql"
+- name: Create database user
+  command: /usr/local/sbin/mysql_create_db.sh {{ mysql_joomla_user }} {{ mysql_joomla_password }}
 
 - name: Joomla
   docker:
@@ -22,8 +11,8 @@
     links:
     - "mysql:mysql"
     env:
-      JOOMLA_DB_USER: joomla
+      JOOMLA_DB_USER: "{{ mysql_joomla_user }}"
       JOOMLA_DB_PASSWORD: "{{ mysql_joomla_password }}"
-      JOOMLA_DB_NAME: joomla
+      JOOMLA_DB_NAME: "{{ mysql_joomla_user }}"
     ports:
     - "80:80"

--- a/provision_profiles/roles/mysql/files/mysql_create_db.sh
+++ b/provision_profiles/roles/mysql/files/mysql_create_db.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+
+function error_usage {
+  echo 'Usage: mysql_createdb.sh username password'
+  echo 'This will create a database by the same name as the username and grant full access to said database to the user.'
+  exit 1
+}
+
+if [ -z "$1" ]; then
+  error_usage
+elif [ -z "$2" ]; then
+  error_usage
+fi
+
+# Define the variables
+MYSQL_USER="$1"
+MYSQL_DATABASE="$1"
+MYSQL_PASSWORD="$2"
+MYSQL_CONTAINER="mysql"
+
+function generate_sql {
+  echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD';"
+  echo "CREATE DATABASE $MYSQL_DATABASE;"
+  echo "GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%';"
+  echo 'FLUSH PRIVILEGES;'
+}
+
+# Create SQL file
+generate_sql > "/tmp/$MYSQL_USER.sql"
+
+# Copy file into container
+docker cp "/tmp/$MYSQL_USER.sql" $MYSQL_CONTAINER:/root/createdb.sql
+
+# Execute the SQL file
+docker exec $MYSQL_CONTAINER sh -c '\
+  exec mysql -uroot -p"$MYSQL_ROOT_PASSWORD"\
+  -e "source /root/createdb.sql;"'
+
+# Clean up
+docker exec $MYSQL_CONTAINER rm /root/createdb.sql

--- a/provision_profiles/roles/mysql/tasks/main.yml
+++ b/provision_profiles/roles/mysql/tasks/main.yml
@@ -11,3 +11,9 @@
     - "/var/lib/mysql:/var/lib/mysql"
     ports:
     - "127.0.0.1:3306:3306"
+
+- name: Copies in createdb script
+  copy:
+    src: mysql_create_db.sh
+    dest: /usr/local/sbin/mysql_create_db.sh
+    mode: 0755

--- a/provision_profiles/roles/owncloud/tasks/main.yml
+++ b/provision_profiles/roles/owncloud/tasks/main.yml
@@ -1,17 +1,6 @@
 ---
-- name: MySQL
-  docker:
-    name: mysql
-    image: mariadb
-    state: started
-    restart_policy: always
-    env:
-      MYSQL_ROOT_PASSWORD: "{{ mysql_root_password }}"
-      MYSQL_USER: owncloud
-      MYSQL_PASSWORD: "{{ mysql_owncloud_password }}"
-      MYSQL_DATABASE: owncloud
-    volumes:
-    - "/var/lib/mysql:/var/lib/mysql"
+- name: Create database user
+  command: /usr/local/sbin/mysql_create_db.sh {{ mysql_owncloud_user }} {{ mysql_owncloud_password }}
 
 - name: Owncloud
   docker:

--- a/provision_profiles/roles/redmine/tasks/main.yml
+++ b/provision_profiles/roles/redmine/tasks/main.yml
@@ -1,18 +1,6 @@
 ---
-- name: MySQL
-  docker:
-    name: mysql
-    image: mariadb
-    state: started
-    restart_policy: on-failure
-    restart_policy_retry: 10
-    env:
-      MYSQL_ROOT_PASSWORD: "{{ mysql_root_password }}"
-      MYSQL_USER: redmine
-      MYSQL_PASSWORD: "{{ mysql_redmine_password }}"
-      MYSQL_DATABASE: redmine
-    volumes:
-    - "/var/lib/mysql:/var/lib/mysql"
+- name: Create database user
+  command: /usr/local/sbin/mysql_create_db.sh {{ mysql_redmine_user }} {{ mysql_redmine_password }}
 
 - name: Create required folders
   file:
@@ -41,8 +29,8 @@
     restart_policy: on-failure
     restart_policy_retry: 10
     env:
-      MYSQL_DATABASE: redmine
-      MYSQL_USER_USER: redmine
+      MYSQL_DATABASE: "{{ mysql_redmine_user }}"
+      MYSQL_USER_USER: "{{ mysql_redmine_user }}"
       MYSWL_PASS: "{{ mysql_redmine_password }}"
     links:
     - "mysql:mysql"

--- a/provision_profiles/roles/redmine/templates/database.yml.j2
+++ b/provision_profiles/roles/redmine/templates/database.yml.j2
@@ -1,8 +1,8 @@
 production:
   adapter: mysql2
-  database: redmine
+  database: {{ mysql_redmine_user }}
   host: mysql
   port: 3306
-  username: redmine
+  username: {{ mysql_redmine_user }}
   password: {{ mysql_redmine_password }}
   encoding: utf8

--- a/provision_profiles/roles/wordpress/tasks/main.yml
+++ b/provision_profiles/roles/wordpress/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create database user
-  command: /usr/local/sbin/mysql_create_db.sh {{ wordpress_user }} {{ mysql_wordpress_password }}
+  command: /usr/local/sbin/mysql_create_db.sh {{ mysql_wordpress_user }} {{ mysql_wordpress_password }}
 
 - name: WordPress
   docker:
@@ -9,9 +9,9 @@
     state: started
     restart_policy: always
     env:
-      WORDPRESS_DB_USER: "{{ wordpress_user }}"
+      WORDPRESS_DB_USER: "{{ mysql_wordpress_user }}"
       WORDPRESS_DB_PASSWORD: "{{ mysql_wordpress_password }}"
-      WORDPRESS_DB_NAME: "{{ wordpress_user }}"
+      WORDPRESS_DB_NAME: "{{ mysql_wordpress_user }}"
     links:
       - "mysql:mysql"
     ports:

--- a/provision_profiles/roles/wordpress/tasks/main.yml
+++ b/provision_profiles/roles/wordpress/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Create database user
+  command: /usr/local/sbin/mysql_create_db.sh {{ wordpress_user }} {{ mysql_wordpress_password }}
+
 - name: WordPress
   docker:
     name: wordpress
@@ -6,7 +9,9 @@
     state: started
     restart_policy: always
     env:
-      MYSQL_ROOT_PASSWORD: "{{ mysql_root_password }}"
+      WORDPRESS_DB_USER: "{{ wordpress_user }}"
+      WORDPRESS_DB_PASSWORD: "{{ mysql_wordpress_password }}"
+      WORDPRESS_DB_NAME: "{{ wordpress_user }}"
     links:
       - "mysql:mysql"
     ports:

--- a/provision_profiles/wordpress.yml
+++ b/provision_profiles/wordpress.yml
@@ -5,7 +5,7 @@
   vars:
     - mysql_root_password:
     - mysql_wordpress_password:
-    - wordpress_user: wordpress
+    - mysql_wordpress_user: wordpress
   roles:
     - unattended-upgrades
     - docker.ubuntu

--- a/provision_profiles/wordpress.yml
+++ b/provision_profiles/wordpress.yml
@@ -3,8 +3,9 @@
   sudo: yes
 
   vars:
-    - mysql_root_password: Riwerlecmainyir
-
+    - mysql_root_password:
+    - mysql_wordpress_password:
+    - wordpress_user: wordpress
   roles:
     - unattended-upgrades
     - docker.ubuntu

--- a/provision_profiles/wordpress_install_notes.tpl
+++ b/provision_profiles/wordpress_install_notes.tpl
@@ -25,5 +25,6 @@ $ docker run -it --link mysql:mysql --rm mariadb sh -c 'exec mysql -hmysql -uroo
 
 ## MySQL
 
-User: root
-Password: `{{ mysql_root_password  }}`
+User: wordpress
+Database: wordpress
+Password: `{{ mysql_wordpress_password  }}`

--- a/provision_profiles/wordpress_install_notes.tpl
+++ b/provision_profiles/wordpress_install_notes.tpl
@@ -4,9 +4,8 @@ Congratulations! You've just installed a WordPress server.
 
 # WordPress Installation Notes
 
- * Point your browser to http://{{ public_ip }}
+ * Point your browser to [http://{{ public_ip  }}](http://{{ public_ip }})
  * Follow the instructions to configure your WordPress site and create your administration account
-
 
 # Technical Details
 


### PR DESCRIPTION
In order to make the MySQL container re-usable across multiple roles, some refactoring was needed. This PR solves this and refactors all playbooks that relies on MySQL to use the same shared container, but isolated into their own database. 